### PR TITLE
fix: fix compilation for `--no-default-features`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub enum Format {
 
 impl Format {
     const fn extension(&self) -> &str {
-        match self {
+        match *self {
             #[cfg(feature = "json")]
             Self::Json => "json",
             #[cfg(feature = "yaml")]
@@ -211,7 +211,7 @@ impl<'a> ConfigLoader<'a> {
         let mut extensions = vec![];
 
         for format in self.formats {
-            match format {
+            match *format {
                 #[cfg(feature = "json")]
                 Format::Json => extensions.push("json"),
                 #[cfg(feature = "yaml")]
@@ -278,7 +278,7 @@ impl<'a> ConfigLoader<'a> {
     ///
     /// If the file cannot be written to the specified path, an error will be returned.
     pub fn save<T: Serialize>(&self, config: &T, format: &Format) -> Result<()> {
-        let str = match format {
+        let str: std::result::Result<String, SerializationError> = match *format {
             #[cfg(feature = "json")]
             Format::Json => serde_json::to_string_pretty(config).map_err(SerializationError::from),
             #[cfg(feature = "yaml")]
@@ -293,7 +293,8 @@ impl<'a> ConfigLoader<'a> {
             Format::Ron => ron::to_string(config).map_err(SerializationError::from),
             #[cfg(feature = "kdl")]
             Format::Kdl => Err(SerializationError::UnsupportedExtension("kdl".to_string())),
-        }?;
+        };
+        let str = str?;
 
         let config_dir = self.config_dir()?;
         let file_name = format!("{}.{}", self.file_name, format.extension());


### PR DESCRIPTION
When no features are enabled the Format enum is empty. This commit fixes a error with type inference and errors with matching a reference to the empty enum by dereferencing them first.

This fixes the compilation of [ironbar](https://github.com/JakeStanger/ironbar) with `--no-default-features`.

I test the changes with the following script:

```sh
#!/bin/sh

check() {
    echo "Checking $1"
    cargo check --no-default-features --features "$@" 2>/dev/null 2>/dev/null
}

cargo check --message-format=short \
&& check '' \
&& check json \
&& check yaml \
&& check toml \
&& check corn \
&& check ron \
&& echo "Check passed" \
|| echo "Check failed"
```